### PR TITLE
fix(github)!: Use gh auth token for GitHub token

### DIFF
--- a/src/bin/github-notifications.rs
+++ b/src/bin/github-notifications.rs
@@ -11,8 +11,9 @@ async fn main() {
 
     // let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
     let token = String::from_utf8(
-        Command::new("pass")
-            .arg("Background/GitHub")
+        Command::new("gh")
+            .arg("auth")
+            .arg("token")
             .output()
             .await
             .expect("Could not get Github token")


### PR DESCRIPTION
BREAKING-CHANGE: gh must be installed and authenticated