### PR TITLE
ci(dependabot): Group minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: monthly
     groups:
-      patches:
+      backwards-compatible:
         update-types:
         - "patch"
+        - "minor"


### PR DESCRIPTION
It is simply too much work for such a personal project to test and merge all these patches one by one, lets combine all updates that *should* be backwards compatible.